### PR TITLE
[BUGFIX] Enforce that projects require at least one flag

### DIFF
--- a/src/app/(protected)/[group]/[subGroup]/[instance]/(admin-panel)/(stage-4)/algorithms-overview/_components/run-algorithm-button.tsx
+++ b/src/app/(protected)/[group]/[subGroup]/[instance]/(admin-panel)/(stage-4)/algorithms-overview/_components/run-algorithm-button.tsx
@@ -48,7 +48,7 @@ export function RunAlgorithmButton({
         error: (err) =>
           err.message === "Infeasible"
             ? "Matching is infeasible with current configuration"
-            : `Something went wrong: ${err.message}`,
+            : `Something went wrong`,
       },
     );
   }

--- a/src/components/instance-form.tsx
+++ b/src/components/instance-form.tsx
@@ -51,7 +51,7 @@ export function InstanceForm({
 }) {
   const defaultInstanceDetails = currentInstanceDetails ?? {
     instanceName: "",
-    flags: [],
+    flags: [{ title: "" }],
     tags: [],
     projectSubmissionDeadline: addDays(new Date(), 1),
     minNumPreferences: 1,
@@ -75,6 +75,7 @@ export function InstanceForm({
   } = useFieldArray({
     control: form.control,
     name: "flags",
+    rules: { minLength: 1 },
   });
 
   const {
@@ -142,9 +143,15 @@ export function InstanceForm({
         )}
         <div className="grid w-full grid-cols-2">
           <div className="flex flex-col gap-2">
-            <FormLabel className="text-base">Project Flags</FormLabel>
+            <FormLabel
+              onError={() => console.log("hello")}
+              className="text-base"
+            >
+              Project Flags
+            </FormLabel>
             <FormDescription>
-              What kind of student is this project suitable for
+              Flags are used to mark a a project as suitable for a particular
+              group of students.
             </FormDescription>
             {flagFields.map((item, idx) => (
               <FormField
@@ -157,7 +164,7 @@ export function InstanceForm({
                       <div className="flex gap-2">
                         <Input
                           placeholder="Flag"
-                          {...form.register(`flags.${idx}.title`)}
+                          {...form.register(`flags.${idx}.title` as const)}
                         />
                         <Button
                           variant="ghost"
@@ -184,6 +191,17 @@ export function InstanceForm({
               <Plus />
               <p>Add new Flag</p>
             </Button>
+            <FormDescription className="text-black">
+              Please note:
+              <ul className="list-disc pl-6">
+                <li>Flag titles must be unique</li>
+                <li>
+                  You must enter{" "}
+                  <span className="font-semibold underline">at least one</span>{" "}
+                  Flag
+                </li>
+              </ul>
+            </FormDescription>
           </div>
 
           <div className="flex flex-col gap-2">

--- a/src/components/instance-form.tsx
+++ b/src/components/instance-form.tsx
@@ -169,6 +169,7 @@ export function InstanceForm({
                         <Button
                           variant="ghost"
                           size="icon"
+                          disabled={flagFields.length === 1}
                           onClick={() => removeFlag(idx)}
                         >
                           <X className="h-4 w-4" />

--- a/src/components/instance-form.tsx
+++ b/src/components/instance-form.tsx
@@ -143,12 +143,7 @@ export function InstanceForm({
         )}
         <div className="grid w-full grid-cols-2">
           <div className="flex flex-col gap-2">
-            <FormLabel
-              onError={() => console.log("hello")}
-              className="text-base"
-            >
-              Project Flags
-            </FormLabel>
+            <FormLabel className="text-base">Project Flags</FormLabel>
             <FormDescription>
               Flags are used to mark a a project as suitable for a particular
               group of students.

--- a/src/lib/validations/instance-form.ts
+++ b/src/lib/validations/instance-form.ts
@@ -8,7 +8,17 @@ const baseSchema = z.object({
   maxPreferencesPerSupervisor: z.number(),
   preferenceSubmissionDeadline: z.date(),
   projectSubmissionDeadline: z.date(),
-  flags: z.array(z.object({ title: z.string() })),
+  flags: z.array(
+    z.object({
+      title: z
+        .string()
+        .min(3, "Please enter a valid title")
+        .refine(
+          (title) => title.startsWith("MSci") || title.startsWith("BSc"),
+          { message: "Valid flag titles start with MSci or BSc" },
+        ),
+    }),
+  ),
   tags: z.array(z.object({ title: z.string() })),
 });
 
@@ -49,6 +59,10 @@ export function buildInstanceFormSchema(takenNames: string[]) {
         })
         .int({ message: "Number must be an integer" })
         .positive(),
+    })
+    .refine(({ flags }) => flags.length > 0, {
+      message: "Please add at least one flag",
+      path: ["flags.0.title"],
     })
     .refine(({ instanceName }) => !takenNames.includes(instanceName), {
       message: "This name is already taken",

--- a/src/lib/validations/project-form.ts
+++ b/src/lib/validations/project-form.ts
@@ -5,7 +5,9 @@ import { tagTypeSchema } from "@/components/tag/tag-input";
 const baseProjectFormSchema = z.object({
   title: z.string().min(4, "Please enter a longer title"),
   description: z.string().min(10, "Please enter a longer description"),
-  flagIds: z.array(z.string()),
+  flagIds: z.array(z.string()).refine((value) => value.some((item) => item), {
+    message: "You have to select at least one flag for a project.",
+  }),
   tags: z.array(z.object({ id: z.string(), title: z.string() })),
   isPreAllocated: z.boolean().optional(),
   capacityUpperBound: z.coerce.number().int().positive(),


### PR DESCRIPTION
**Completed**
- All instances created must have at least one flag available for supervisors to assign to their projects
- All projects require that at least one flag is assigned to them
- Flags titles must start with either "MSci" or "BSc"

**TODO**
- Allow superadmin or Group Admin to create custom validation for flag titles from within the app
- Improve Instance creation form UX (make descriptions, notes, and errors more consistent across forms)