### PR TITLE
[SECURITY] Harden psql

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres:latest
     ports:
-      - "6565:5432"
+      - "127.0.0.1:6565:5432"
     volumes:
       - spa-db-data:/var/lib/postgres/data/
     environment:


### PR DESCRIPTION
As it stands, the postgresql port is forwarded to port 6565 on all interfaces (meaning that I can just use psql to connect to port 6565 on carlos and get complete access to the database). The following change restricts this port forward to only localhost on carlos, so one would need to be on carlos to connect. This is still not ideal (the ideal world is not needing to forward any psql port outside the docker network) but the db:populate and db:reset commands would not work from carlos without any port forwarded.