### PR TITLE
[REFACTOR] Shibboleth SSO Integration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -323,3 +323,9 @@ model VerificationToken {
 
     @@unique([identifier, token])
 }
+
+model NewUser {
+    id    String @id
+    name  String
+    email String @unique
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
 
+// TODO: remove this entire layout as the whole application is protected by shibboleth
 export default async function Layout({
   children,
 }: {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,1 +1,2 @@
+// TODO: potentially remove after new auth is implemented
 export { GET, POST } from "@/lib/auth";

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -23,6 +23,7 @@ export function OPTIONS() {
   return response;
 }
 
+// TODO: replace with slimmed down auth function
 const handler = auth(async (req) => {
   const response = await fetchRequestHandler({
     endpoint: "/api/trpc",
@@ -30,7 +31,7 @@ const handler = auth(async (req) => {
     req,
     createContext: () =>
       createTRPCContext({
-        session: req.auth,
+        session: req.auth, // ! req might not return auth
         headers: req.headers,
       }),
     onError({ error, path }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { UserInstances } from "@/components/user-instances";
 
 import { auth } from "@/lib/auth";
 
+// TODO: remove auth check, can assume that a user exists since the application is protected by shibboleth
 export default async function Home() {
   const session = await auth();
   const user = session?.user;

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -12,6 +12,7 @@ import { UserButton } from "./user-button";
 import whiteLogo from "@/assets/uofg-white.png";
 
 export async function Header() {
+  // TODO: refactor once new auth is implemented, can assume that user will be signed in
   const session = await auth();
   const adminPanel = await api.user.adminPanelRoute();
 

--- a/src/lib/auth/new-auth.ts
+++ b/src/lib/auth/new-auth.ts
@@ -1,0 +1,5 @@
+import { Session } from "next-auth/types";
+
+export declare function slim_auth(): Promise<Session | null>;
+// TODO: implement function to get session
+// can potentially get this from JWT or cookies?

--- a/src/lib/auth/new-auth.ts
+++ b/src/lib/auth/new-auth.ts
@@ -8,6 +8,31 @@ type NewSession = {
   user: NewUser;
 };
 
-export declare function slim_auth(): Promise<NewSession | null>;
-// TODO: implement function to get session
-// can potentially get this from JWT or cookies?
+// Function to read cookies
+function getCookie(name: string): string | null {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(';').shift() || null;
+  return null;
+}
+
+// TODO: maybe not the best way todo this?
+export async function slim_auth(): Promise<NewSession | null> {
+  try {
+    // Retrieve the user cookie
+    const userCookie = getCookie('user');
+    if (!userCookie) return null;
+
+    // Parse the cookie JSON into a NewSession object
+    const session = JSON.parse(userCookie) as NewSession;
+
+    // Check if the session is valid
+    if (session && session.userId) {
+      return session;
+    }
+    return null;
+  } catch (error) {
+    console.error('Error parsing session cookie:', error);
+    return null;
+  }
+}

--- a/src/lib/auth/new-auth.ts
+++ b/src/lib/auth/new-auth.ts
@@ -1,5 +1,13 @@
-import { Session } from "next-auth/types";
+import { NewUser } from "@prisma/client";
 
-export declare function slim_auth(): Promise<Session | null>;
+type NewSession = {
+  id: string;
+  sessionToken: string;
+  userId: string;
+  expires: number;
+  user: NewUser;
+};
+
+export declare function slim_auth(): Promise<NewSession | null>;
 // TODO: implement function to get session
 // can potentially get this from JWT or cookies?

--- a/src/lib/auth/new.ts
+++ b/src/lib/auth/new.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { PrismaClient } from "@prisma/client";
+
+type ShibUser = {
+  guid: string;
+  displayName: string;
+  email: string;
+  groups: string[]; // TODO: check what the actual type of this is
+};
+
+export async function getUserAction(db: PrismaClient, user: ShibUser) {
+  const dbUser = await db.newUser.findFirst({ where: { id: user.guid } });
+  if (dbUser) return dbUser;
+
+  const newUser = await createUserAction(db, user);
+  return newUser;
+}
+
+async function createUserAction(db: PrismaClient, user: ShibUser) {
+  return await db.newUser.create({
+    data: {
+      id: user.guid,
+      name: user.displayName,
+      email: user.email,
+    },
+  });
+}
+
+// TODO: create panel for super-admin to add SupervisorInstanceDetails or StudentDetails

--- a/src/lib/trpc/server.ts
+++ b/src/lib/trpc/server.ts
@@ -15,7 +15,7 @@ const createContext = cache(async () => {
   heads.set("x-trpc-source", "rsc");
 
   return createTRPCContext({
-    session: await auth(),
+    session: await auth(), // TODO: replace with slimmed down auth function
     headers: heads,
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,36 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "./lib/db";
+import { getUserAction } from "./lib/auth/new";
+import { z } from "zod";
 
-export function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest) {
   // Extract the headers from the request
-  const guid = req.headers.get('DH75HDYT76');
-  const displayName = req.headers.get('DH75HDYT77');
-  const groups = req.headers.get('DH75HDYT78');
+  const shib_guid = req.headers.get("DH75HDYT76");
+  const shib_displayName = req.headers.get("DH75HDYT77");
+  const shib_groups = req.headers.get("DH75HDYT78");
 
   // Log the headers to the console
-  console.log('GUID:', guid);
-  console.log('Display Name:', displayName);
-  console.log('Groups:', groups);
+  console.log("GUID:", shib_guid);
+  console.log("Display Name:", shib_displayName);
+  console.log("Groups:", shib_groups);
+
+  // Parse the headers into their expected types
+  const id = z.string().parse(shib_guid);
+  const displayName = z.string().parse(shib_displayName);
+  const email = "";
+  const groups = [] as string[];
+
+  const user = await getUserAction(db, {
+    guid: id,
+    displayName,
+    email,
+    groups,
+  });
+
+  // TODO: add the user / session to the cookies
 
   // Continue to the next middleware or the request handler
   return NextResponse.next();
 }
 
-export const config = {
-  matcher: '/:path*', // Apply this middleware to all routes
-};
+export const config = { matcher: "/:path*" };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  // Extract the headers from the request
+  const guid = req.headers.get('DH75HDYT76');
+  const displayName = req.headers.get('DH75HDYT77');
+  const groups = req.headers.get('DH75HDYT78');
+
+  // Log the headers to the console
+  console.log('GUID:', guid);
+  console.log('Display Name:', displayName);
+  console.log('Groups:', groups);
+
+  // Continue to the next middleware or the request handler
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/:path*', // Apply this middleware to all routes
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db } from "./lib/db";
-import { getUserAction } from "./lib/auth/new";
 import { z } from "zod";
+
+import { getUserAction } from "./lib/auth/new";
+import { db } from "./lib/db";
 
 export async function middleware(req: NextRequest) {
   // Extract the headers from the request
@@ -28,9 +29,13 @@ export async function middleware(req: NextRequest) {
   });
 
   // TODO: add the user / session to the cookies
+  // TODO: figure out if this is the best / optimal way todo this.
+  const response = NextResponse.next();
+  response.cookies.set('user', JSON.stringify(user), { httpOnly: true, path: '/' });
 
   // Continue to the next middleware or the request handler
-  return NextResponse.next();
+  return response;
+
 }
 
 export const config = { matcher: "/:path*" };

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -32,7 +32,19 @@ export const createTRPCContext = async (opts: {
   headers: Headers;
   session: Session | null;
 }) => {
-  const session = opts.session ?? (await auth());
+  const session = opts.session ?? (await auth()); // TODO: replace with slimmed down auth function
+
+  if (!session) {
+    // TODO: check headers for shibboleth headers
+    // if there's a header indicating that a user exists
+    // (like an Authorization header or something)
+    // -> return a new session with the correct user attached
+    //
+    // otherwise
+    // -> return an empty session / null / throw an error
+    // (not sure what the right call is here)
+  }
+
   const source = opts.headers.get("x-trpc-source") ?? "unknown";
 
   console.log(">>> tRPC Request from", source, "by", session?.user);


### PR DESCRIPTION
> [!Caution]
> This PR will remove `next-auth` and allow only authentication through a `Shibboleth SSO`.

### Implementation Plan
* `middleware.ts` - catch `HTTP` headers
* Use Next v14 server actions.
* New user session type to store a shibboleth user `{guid, displayName, unscopedAffiliations}`
* Fully remove `next-auth` and refactor `schema.prisma`