### PR TITLE
[BUGFIX] Correctly derive profile state from allProjects in context

### DIFF
--- a/src/lib/utils/allocation-adjustment/index.ts
+++ b/src/lib/utils/allocation-adjustment/index.ts
@@ -1,4 +1,4 @@
-export { getPreferenceRank, getUpdatedWeight } from "./matching-info";
+export { getPreferenceRank } from "./matching-info";
 export {
   allProjectsValid,
   getAsProjects,

--- a/src/lib/utils/allocation-adjustment/matching-info.ts
+++ b/src/lib/utils/allocation-adjustment/matching-info.ts
@@ -5,12 +5,6 @@ import {
 
 import { getAsProjects } from "./project";
 
-export function getUpdatedWeight(profile: number[]) {
-  return profile.reduce((acc, val, i) => {
-    return acc + val * (i + 1);
-  }, 0);
-}
-
 function getStudentProjects(allProjects: ProjectInfo[], row: StudentRow) {
   return getAsProjects(allProjects, row.projects);
 }


### PR DESCRIPTION
`profile` state was not properly derived from the context and so would not update when the projects state got updated. Fixed and memoised computation of `profile` so it now updates when either dependency changes