### PR TITLE
[BUGFIX] Admin panel actions access control

### DIFF
--- a/src/app/(protected)/[group]/[subGroup]/page.tsx
+++ b/src/app/(protected)/[group]/[subGroup]/page.tsx
@@ -58,9 +58,11 @@ export default async function Page({
               ))}
             </TableBody>
           </Table>
-          <div className="mt-2">
-            <FormButton params={params} />
-          </div>
+          <AdminLevelAC minimumAdminLevel={AdminLevel.GROUP}>
+            <div className="mt-2">
+              <FormButton params={params} />
+            </div>
+          </AdminLevelAC>
         </CardContent>
       </Card>
       <SubHeading>Manage {spacesLabels.instance.full}s</SubHeading>

--- a/src/app/(protected)/[group]/page.tsx
+++ b/src/app/(protected)/[group]/page.tsx
@@ -52,9 +52,11 @@ export default async function Page({ params }: { params: { group: string } }) {
               ))}
             </TableBody>
           </Table>
-          <div className="mt-2">
-            <FormButton params={params} />
-          </div>
+          <AdminLevelAC minimumAdminLevel={AdminLevel.SUPER}>
+            <div className="mt-2">
+              <FormButton params={params} />
+            </div>
+          </AdminLevelAC>
         </CardContent>
       </Card>
       <SubHeading>Manage {spacesLabels.subGroup.full}s</SubHeading>


### PR DESCRIPTION
**Completed**
- admins can only be added to a group or subgroup by a higher level admin

**TODO**
- check that this is the desired behaviour
- the opposite may have been what the users expected in which case it's simply a matter of removing the access control component wrapper from the buttons and forms