### PR TITLE
[HOTFIX] Don't require `projectId` when creating a project

### DIFF
--- a/src/server/routers/project/index.ts
+++ b/src/server/routers/project/index.ts
@@ -16,11 +16,8 @@ import {
   createTRPCRouter,
   instanceAdminProcedure,
   instanceProcedure,
-  projectProcedure,
   protectedProcedure,
 } from "@/server/trpc";
-
-import { requiredFlags } from "@/content/config/flags";
 
 export const projectRouter = createTRPCRouter({
   exists: instanceProcedure
@@ -535,13 +532,19 @@ export const projectRouter = createTRPCRouter({
       },
     ),
 
-  getFormDetails: projectProcedure
-    .input(z.object({ params: instanceParamsSchema, projectId: z.string().optional() }))
+  getFormDetails: instanceProcedure
+    .input(
+      z.object({
+        params: instanceParamsSchema,
+        projectId: z.string().optional(),
+      }),
+    )
     .query(
       async ({
         ctx,
         input: {
           params: { group, subGroup, instance },
+          projectId,
         },
       }) => {
         const { flags, tags } =
@@ -572,6 +575,15 @@ export const projectRouter = createTRPCRouter({
           },
         });
 
+        let projectFlags: Set<string> = new Set();
+        if (projectId) {
+          const projectData = await ctx.db.flagOnProject.findMany({
+            where: { projectId },
+            select: { flag: true },
+          });
+          projectFlags = new Set(projectData.map(({ flag }) => flag.title));
+        }
+
         const projectTitles = await ctx.db.project.findMany({
           where: {
             allocationGroupId: group,
@@ -580,29 +592,23 @@ export const projectRouter = createTRPCRouter({
           },
           select: { title: true },
         });
-        var sd = studentData;
-        if (ctx.project) {
-            sd = sd
-            .filter((s) => {
-              if (requiredFlags.length === 0) return true;
-              return ctx.project.flags.some((f) => {
-                return (
-                  getStudentLevelFromFlag(f) ===
-                  s.studentDetails[0].studentLevel
-                );
-              });
-            })
-        }
-        sd = sd
-            .map(({ studentDetails }) => ({
-              id: studentDetails[0].userId,
-              studentLevel: studentDetails[0].studentLevel,
-            }));
+
+        const students = studentData
+          .map(({ studentDetails }) => ({
+            id: studentDetails[0].userId,
+            studentLevel: studentDetails[0].studentLevel,
+          }))
+          .filter((s) =>
+            projectId
+              ? projectFlags.has(getFlagFromStudentLevel(s.studentLevel))
+              : true,
+          );
+
         return {
           takenTitles: projectTitles.map(({ title }) => title),
           flags,
           tags,
-          students: sd,
+          students,
         };
       },
     ),

--- a/src/server/routers/project/index.ts
+++ b/src/server/routers/project/index.ts
@@ -536,7 +536,7 @@ export const projectRouter = createTRPCRouter({
     ),
 
   getFormDetails: projectProcedure
-    .input(z.object({ params: instanceParamsSchema, projectId: z.string() }))
+    .input(z.object({ params: instanceParamsSchema, projectId: z.string().optional() }))
     .query(
       async ({
         ctx,
@@ -580,12 +580,9 @@ export const projectRouter = createTRPCRouter({
           },
           select: { title: true },
         });
-
-        return {
-          takenTitles: projectTitles.map(({ title }) => title),
-          flags,
-          tags,
-          students: studentData
+        var sd = studentData;
+        if (ctx.project) {
+            sd = sd
             .filter((s) => {
               if (requiredFlags.length === 0) return true;
               return ctx.project.flags.some((f) => {
@@ -595,10 +592,17 @@ export const projectRouter = createTRPCRouter({
                 );
               });
             })
+        }
+        sd = sd
             .map(({ studentDetails }) => ({
               id: studentDetails[0].userId,
               studentLevel: studentDetails[0].studentLevel,
-            })),
+            }));
+        return {
+          takenTitles: projectTitles.map(({ title }) => title),
+          flags,
+          tags,
+          students: sd,
         };
       },
     ),


### PR DESCRIPTION
**Completed**

- changed the `getFormDetails` procedure from a `projectProcedure` to an `instanceProcedure` to allow calling it without a projectId
- filter the available students based on the flag, only when calling the procedure in the edit form page