### PR TITLE
[FEATURE] Allow admins to create student-defined projects at Project Selection stage

### DIFF
--- a/src/app/(protected)/[group]/[subGroup]/[instance]/layout.tsx
+++ b/src/app/(protected)/[group]/[subGroup]/[instance]/layout.tsx
@@ -44,10 +44,12 @@ export default async function Layout({
   }
 
   const stage = await api.institution.instance.currentStage({ params });
+  const roles = await api.user.roles({ params });
+
   const { flags, tags } = await api.project.details({ params });
 
   return (
-    <InstanceParamsProvider params={{ params, stage }}>
+    <InstanceParamsProvider params={{ params, stage, roles }}>
       <DataTableProvider details={{ flags, tags }}>
         {children}
       </DataTableProvider>

--- a/src/components/kanban-board/project-preference-card.tsx
+++ b/src/components/kanban-board/project-preference-card.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { stageGte } from "@/lib/utils/permissions/stage-check";
 import { ProjectPreference } from "@/lib/validations/board";
+
 import { WithTooltip } from "../ui/tooltip-wrapper";
 
 export function ProjectPreferenceCard({

--- a/src/components/pages/create-project-form.tsx
+++ b/src/components/pages/create-project-form.tsx
@@ -56,7 +56,7 @@ export function CreateProjectForm({
       requiredFlags={requiredFlags}
     >
       <Button variant="outline" size="lg" type="button" asChild>
-        <Link className="w-32" href={`./my-projects`}>
+        <Link className="w-32" href={createdByAdmin ? "." : "./my-projects"}>
           Cancel
         </Link>
       </Button>

--- a/src/components/params-context.tsx
+++ b/src/components/params-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { createContext, ReactNode, useContext } from "react";
-import { Stage } from "@prisma/client";
+import { Role, Stage } from "@prisma/client";
 import { ArrowUpLeft } from "lucide-react";
 import Link from "next/link";
 
@@ -9,7 +9,7 @@ import { InstanceParams } from "@/lib/validations/params";
 
 const InstanceContext = createContext<Instance | undefined>(undefined);
 
-type Instance = { params: InstanceParams; stage: Stage };
+type Instance = { params: InstanceParams; stage: Stage; roles: Set<Role> };
 
 export function InstanceParamsProvider({
   children,
@@ -41,6 +41,12 @@ export function useInstanceStage() {
   const instance = useContext(InstanceContext);
   if (!instance) throw new Error("Missing InstanceParamsProvider in the tree");
   return instance.stage;
+}
+
+export function useInstanceRoles() {
+  const instance = useContext(InstanceContext);
+  if (!instance) throw new Error("Missing InstanceParamsProvider in the tree");
+  return instance.roles;
 }
 
 export function InstanceHomeRedirectButton() {

--- a/src/components/project-form.tsx
+++ b/src/components/project-form.tsx
@@ -48,7 +48,11 @@ import {
 
 import { AccessControl } from "./access-control";
 import { MarkdownEditor } from "./markdown-editor";
-import { useInstancePath } from "./params-context";
+import {
+  useInstancePath,
+  useInstanceRoles,
+  useInstanceStage,
+} from "./params-context";
 
 import { spacesLabels } from "@/content/spaces";
 
@@ -70,6 +74,9 @@ export function ProjectForm({
   children: ReactNode;
 }) {
   const instancePath = useInstancePath();
+  const stage = useInstanceStage();
+  const userRoles = useInstanceRoles();
+
   const formProject = {
     title: project?.title ?? "",
     description: project?.description ?? "",
@@ -102,6 +109,7 @@ export function ProjectForm({
     },
   });
 
+  // TODO: somehow projects are created with the preAllocatedStudentId set to an empty string
   function handleSwitch() {
     const newState = !preAllocatedSwitchControl;
 
@@ -306,6 +314,12 @@ export function ProjectForm({
         <AccessControl
           allowedStages={[Stage.PROJECT_SUBMISSION]}
           allowedRoles={[Role.ADMIN, Role.SUPERVISOR]}
+          extraConditions={{
+            SBAC: {
+              OR:
+                stage === Stage.PROJECT_SELECTION && userRoles.has(Role.ADMIN),
+            },
+          }}
         >
           <FormField
             control={form.control}
@@ -368,7 +382,16 @@ export function ProjectForm({
               )}
             />
           </AccessControl>
-          <AccessControl allowedStages={[Stage.PROJECT_SUBMISSION]}>
+          <AccessControl
+            allowedStages={[Stage.PROJECT_SUBMISSION]}
+            extraConditions={{
+              SBAC: {
+                OR:
+                  stage === Stage.PROJECT_SELECTION &&
+                  userRoles.has(Role.ADMIN),
+              },
+            }}
+          >
             <FormField
               control={form.control}
               name="preAllocatedStudentId"

--- a/src/lib/validations/dto/project.ts
+++ b/src/lib/validations/dto/project.ts
@@ -1,7 +1,7 @@
+import { title } from "process";
 import { z } from "zod";
 
 import { tagTypeSchema } from "@/components/tag/tag-input";
-import { title } from "process";
 
 export const projectDtoSchema = z.object({
   title: z.string(),


### PR DESCRIPTION
**Completed**

Closes #211 

- added user roles to instance context
- updated access control, use user roles to determine if user can create student-defined projects at stage 3
- minor fix to dismissal button in create project form when user is an admin