### PR TITLE
hotfix: Fix notify late markers button

### DIFF
--- a/src/app/(protected)/[group]/[subGroup]/[instance]/(admin-panel)/(stage-specific)/(stage-9)/marking-overview/notify-late-markers-button.tsx
+++ b/src/app/(protected)/[group]/[subGroup]/[instance]/(admin-panel)/(stage-specific)/(stage-9)/marking-overview/notify-late-markers-button.tsx
@@ -3,9 +3,10 @@
 import { SendIcon } from "lucide-react";
 import { toast } from "sonner";
 
-import { type UserDTO } from "@/dto";
+import { type LateBlame, type UserDTO } from "@/dto";
 
 import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { YesNoAction } from "@/components/yes-no-action";
 
 import { api } from "@/lib/trpc/client";
@@ -16,7 +17,7 @@ export function NotifyLateMarkersButton({
   lateMarkers,
 }: {
   params: InstanceParams;
-  lateMarkers: UserDTO[];
+  lateMarkers: { marker: UserDTO; blame: LateBlame[] }[];
 }) {
   const { mutateAsync: api_notifyLateMarkers } =
     api.msp.admin.instance.notifyLateMarkers.useMutation();
@@ -25,7 +26,7 @@ export function NotifyLateMarkersButton({
     <YesNoAction
       title="Notify late markers"
       description={
-        <>
+        <div>
           <p>
             This will send a single email to any marker who has any overdue unit
             of assessment as of now.
@@ -33,7 +34,33 @@ export function NotifyLateMarkersButton({
             This will email {lateMarkers.length} markers. Do you wish to
             continue?
           </p>
-        </>
+
+          <p className="my-2 text-primary">
+            A breakdown of the markers you are about to email, and why, is
+            below:
+          </p>
+
+          <ScrollArea className="h-[40dvh] text-accent-foreground pr-2 bg-accent rounded-md my-2">
+            <ol>
+              {lateMarkers.map((m) => (
+                <div key={m.marker.id} className="m-2">
+                  <div className="text-lg">{m.marker.name}</div>
+                  <ol className="list-disc">
+                    {m.blame.map((b, i) => (
+                      <li
+                        key={i}
+                        className="flex flex-row justify-between ml-2"
+                      >
+                        <p>{b.student.name}</p>
+                        <p>{b.unit.title}</p>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              ))}
+            </ol>
+          </ScrollArea>
+        </div>
       }
       trigger={
         <Button variant="outline">

--- a/src/app/(protected)/[group]/[subGroup]/[instance]/(admin-panel)/(stage-specific)/(stage-9)/marking-overview/notify-late-markers-button.tsx
+++ b/src/app/(protected)/[group]/[subGroup]/[instance]/(admin-panel)/(stage-specific)/(stage-9)/marking-overview/notify-late-markers-button.tsx
@@ -41,24 +41,19 @@ export function NotifyLateMarkersButton({
           </p>
 
           <ScrollArea className="h-[40dvh] text-accent-foreground pr-2 bg-accent rounded-md my-2">
-            <ol>
-              {lateMarkers.map((m) => (
-                <div key={m.marker.id} className="m-2">
-                  <div className="text-lg">{m.marker.name}</div>
-                  <ol className="list-disc">
-                    {m.blame.map((b, i) => (
-                      <li
-                        key={i}
-                        className="flex flex-row justify-between ml-2"
-                      >
-                        <p>{b.student.name}</p>
-                        <p>{b.unit.title}</p>
-                      </li>
-                    ))}
-                  </ol>
-                </div>
-              ))}
-            </ol>
+            {lateMarkers.map((m) => (
+              <div key={m.marker.id} className="m-2">
+                <div className="text-lg">{m.marker.name}</div>
+                <ul className="list-disc pl-2">
+                  {m.blame.map((b, i) => (
+                    <li key={i} className="grid grid-cols-2 place-items-start">
+                      <p>{b.student.name}</p>
+                      <p>{b.unit.title}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </ScrollArea>
         </div>
       }

--- a/src/data-objects/space/instance.ts
+++ b/src/data-objects/space/instance.ts
@@ -2056,8 +2056,8 @@ export class AllocationInstance extends DataObject {
             INCOMPLETE_STATUSES.includes(u.status),
         ),
       )
-      .flatMap((d) => {
-        return d.units
+      .flatMap((d) =>
+        d.units
           .filter(
             (u) =>
               u.status === UnitGradingLifecycleState.IN_NEGOTIATION ||
@@ -2083,8 +2083,8 @@ export class AllocationInstance extends DataObject {
                   : { user: T.toUserDTO(d.supervisor), blame };
               }
             }
-          });
-      })
+          }),
+      )
       .filter(Boolean);
 
     const distinctMarkers = groupBy(markers, (m) => m.user.id);

--- a/src/data-objects/space/instance.ts
+++ b/src/data-objects/space/instance.ts
@@ -42,6 +42,7 @@ import {
   AllocationMethod,
   DB_ReaderPreferenceType,
   ExtendedReaderPreferenceType,
+  MarkerType,
   Stage,
   type DB,
   type New,
@@ -2035,7 +2036,9 @@ export class AllocationInstance extends DataObject {
     });
   }
 
-  public async getLateMarkers(): Promise<UserDTO[]> {
+  public async getLateMarkers(): Promise<
+    { id: string; user: UserDTO; blame: string }[]
+  > {
     const data = await this.getStudentMarkingStatus();
     const today = Date.now();
 
@@ -2054,28 +2057,66 @@ export class AllocationInstance extends DataObject {
         ),
       )
       .flatMap((d) => {
+        // If this is the case, we can blame both:
         if (
           d.units.some(
             (u) =>
               u.status === UnitGradingLifecycleState.IN_NEGOTIATION ||
-              u.status === UnitGradingLifecycleState.REQUIRES_MARKING,
+              (u.status === UnitGradingLifecycleState.REQUIRES_MARKING &&
+                u.unit.allowedMarkerTypes.length === 2),
           )
         ) {
-          return [d.supervisor, d.reader];
+          return [
+            {
+              id: d.supervisor.id,
+              user: T.toUserDTO(d.supervisor),
+              blame: `${d.student.name} - both`,
+            },
+            {
+              id: d.reader!.id,
+              user: T.toUserDTO(d.reader!),
+              blame: `${d.student.name} - both`,
+            },
+          ];
         }
 
+        // Otherwise, it's just one
         return d.units
           .filter(
-            (u) => u.status === UnitGradingLifecycleState.PENDING_2ND_MARKER,
+            (u) =>
+              u.status === UnitGradingLifecycleState.PENDING_2ND_MARKER ||
+              u.status === UnitGradingLifecycleState.REQUIRES_MARKING,
           )
-          .map((u) =>
-            u.submissions.find((x) => x.markerId === d.supervisor.id)
-              ? d.reader
-              : d.supervisor,
-          );
+          .map((u) => {
+            if (u.status === UnitGradingLifecycleState.PENDING_2ND_MARKER) {
+              return u.submissions.find((x) => x.markerId === d.supervisor.id)
+                ? {
+                    id: d.reader!.id,
+                    user: T.toUserDTO(d.reader!),
+                    blame: `${d.student.name} - ${u.unit.title}`,
+                  }
+                : {
+                    id: d.supervisor.id,
+                    user: T.toUserDTO(d.supervisor),
+                    blame: `${d.student.name} - ${u.unit.title}`,
+                  };
+            } else {
+              // it requires marking...
+              return u.unit.allowedMarkerTypes[0] === MarkerType.READER
+                ? {
+                    id: d.reader!.id,
+                    user: T.toUserDTO(d.reader!),
+                    blame: `${d.student.name} - ${u.unit.title}`,
+                  }
+                : {
+                    id: d.supervisor.id,
+                    user: T.toUserDTO(d.supervisor),
+                    blame: `${d.student.name} - ${u.unit.title}`,
+                  };
+            }
+          });
       })
-      .filter(Boolean)
-      .map((x) => T.toUserDTO(x));
+      .filter(Boolean);
 
     return uniqueById(markers);
   }

--- a/src/data-objects/space/instance.ts
+++ b/src/data-objects/space/instance.ts
@@ -30,6 +30,7 @@ import {
   type UnitGradeDTO,
   type UnitOfAssessmentDTO,
   type UserDTO,
+  type LateBlame,
 } from "@/dto";
 import {
   type StudentDelta,
@@ -85,7 +86,6 @@ export const byDisplayName = <T extends { displayName: string }>({
   displayName,
 }: T) => displayName;
 
-type LateBlame = { student: UserDTO; unit: UnitOfAssessmentDTO };
 export class AllocationInstance extends DataObject {
   async getUnitOfAssessment(
     unitOfAssessmentId: string,

--- a/src/data-objects/space/instance.ts
+++ b/src/data-objects/space/instance.ts
@@ -58,7 +58,6 @@ import { expand, toInstanceId } from "@/lib/utils/general/instance-params";
 import { setDiff } from "@/lib/utils/general/set-difference";
 import { groupBy } from "@/lib/utils/group-by";
 import { keyBy } from "@/lib/utils/key-by";
-import { uniqueById } from "@/lib/utils/list-unique";
 import { type InstanceParams } from "@/lib/validations/params";
 import { type TabType } from "@/lib/validations/tabs";
 
@@ -86,6 +85,7 @@ export const byDisplayName = <T extends { displayName: string }>({
   displayName,
 }: T) => displayName;
 
+type LateBlame = { student: UserDTO; unit: UnitOfAssessmentDTO };
 export class AllocationInstance extends DataObject {
   async getUnitOfAssessment(
     unitOfAssessmentId: string,
@@ -2037,7 +2037,7 @@ export class AllocationInstance extends DataObject {
   }
 
   public async getLateMarkers(): Promise<
-    { id: string; user: UserDTO; blame: string }[]
+    { marker: UserDTO; blame: LateBlame[] }[]
   > {
     const data = await this.getStudentMarkingStatus();
     const today = Date.now();
@@ -2057,68 +2057,42 @@ export class AllocationInstance extends DataObject {
         ),
       )
       .flatMap((d) => {
-        // If this is the case, we can blame both:
-        if (
-          d.units.some(
-            (u) =>
-              u.status === UnitGradingLifecycleState.IN_NEGOTIATION ||
-              (u.status === UnitGradingLifecycleState.REQUIRES_MARKING &&
-                u.unit.allowedMarkerTypes.length === 2),
-          )
-        ) {
-          return [
-            {
-              id: d.supervisor.id,
-              user: T.toUserDTO(d.supervisor),
-              blame: `${d.student.name} - both`,
-            },
-            {
-              id: d.reader!.id,
-              user: T.toUserDTO(d.reader!),
-              blame: `${d.student.name} - both`,
-            },
-          ];
-        }
-
-        // Otherwise, it's just one
         return d.units
           .filter(
             (u) =>
+              u.status === UnitGradingLifecycleState.IN_NEGOTIATION ||
               u.status === UnitGradingLifecycleState.PENDING_2ND_MARKER ||
               u.status === UnitGradingLifecycleState.REQUIRES_MARKING,
           )
-          .map((u) => {
+          .flatMap((u) => {
+            const blame = { student: T.toUserDTO(d.student), unit: u.unit };
+
             if (u.status === UnitGradingLifecycleState.PENDING_2ND_MARKER) {
               return u.submissions.find((x) => x.markerId === d.supervisor.id)
-                ? {
-                    id: d.reader!.id,
-                    user: T.toUserDTO(d.reader!),
-                    blame: `${d.student.name} - ${u.unit.title}`,
-                  }
-                : {
-                    id: d.supervisor.id,
-                    user: T.toUserDTO(d.supervisor),
-                    blame: `${d.student.name} - ${u.unit.title}`,
-                  };
+                ? { user: T.toUserDTO(d.reader!), blame }
+                : { user: T.toUserDTO(d.supervisor), blame };
             } else {
-              // it requires marking...
-              return u.unit.allowedMarkerTypes[0] === MarkerType.READER
-                ? {
-                    id: d.reader!.id,
-                    user: T.toUserDTO(d.reader!),
-                    blame: `${d.student.name} - ${u.unit.title}`,
-                  }
-                : {
-                    id: d.supervisor.id,
-                    user: T.toUserDTO(d.supervisor),
-                    blame: `${d.student.name} - ${u.unit.title}`,
-                  };
+              if (u.unit.allowedMarkerTypes.length === 2) {
+                return [
+                  { user: T.toUserDTO(d.supervisor), blame },
+                  { user: T.toUserDTO(d.reader!), blame },
+                ];
+              } else {
+                return u.unit.allowedMarkerTypes[0] === MarkerType.READER
+                  ? { user: T.toUserDTO(d.reader!), blame }
+                  : { user: T.toUserDTO(d.supervisor), blame };
+              }
             }
           });
       })
       .filter(Boolean);
 
-    return uniqueById(markers);
+    const distinctMarkers = groupBy(markers, (m) => m.user.id);
+
+    return Object.values(distinctMarkers).map((xs) => ({
+      marker: xs[0].user,
+      blame: xs.map((x) => x.blame),
+    }));
   }
 }
 

--- a/src/dto/user.ts
+++ b/src/dto/user.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { flagDtoSchema } from "./flag-tag";
+import { unitOfAssessmentDtoSchema } from "./marking";
 
 export const userDtoSchema = z.object({
   id: z.string(),
@@ -36,6 +37,13 @@ export const readerDtoSchema = instanceUserDtoSchema.extend({
 });
 
 export type ReaderDTO = z.infer<typeof readerDtoSchema>;
+
+export const lateBlameSchema = z.object({
+  student: userDtoSchema,
+  unit: unitOfAssessmentDtoSchema,
+});
+
+export type LateBlame = z.infer<typeof lateBlameSchema>;
 
 export const studentDtoSchema = instanceUserDtoSchema.extend({
   latestSubmission: z.date().optional(),

--- a/src/logic/grading.ts
+++ b/src/logic/grading.ts
@@ -169,6 +169,8 @@ export class Grade {
   ): UnitGradingLifecycleState {
     if (!unit.isOpen) {
       return UnitGradingLifecycleState.CLOSED;
+    } else if (grade?.customWeight === 0) {
+      return UnitGradingLifecycleState.DONE;
     } else if (!grade?.studentSubmitted) {
       return UnitGradingLifecycleState.NOT_SUBMITTED;
     } else if (grade?.status === ConsensusStage.MODERATE) {

--- a/src/server/routers/msp/admin/instace.ts
+++ b/src/server/routers/msp/admin/instace.ts
@@ -132,19 +132,17 @@ export const mspAdminInstanceRouter = createTRPCRouter({
     .output(z.void())
 
     .mutation(async ({ ctx: { mailer, instance, logger, user } }) => {
-      const markers = await instance.getLateMarkers();
+      const markerBlame = await instance.getLateMarkers();
+      const markers = markerBlame.map((m) => m.marker);
 
       logger.log(LogLevels.AUDIT, "Sending marking reminders", {
         numAcademics: markers.length,
         authorizerId: user.id,
       });
 
-      console.log(markers);
-      console.log(markers.length);
-
-      // await mailer.notifyGenericMarkingOverdue({
-      //   params: instance.params,
-      //   markers,
-      // });
+      await mailer.notifyGenericMarkingOverdue({
+        params: instance.params,
+        markers,
+      });
     }),
 });

--- a/src/server/routers/msp/admin/instace.ts
+++ b/src/server/routers/msp/admin/instace.ts
@@ -122,7 +122,7 @@ export const mspAdminInstanceRouter = createTRPCRouter({
   getLateMarkers: procedure.instance.subGroupAdmin
     .output(z.array(userDtoSchema))
     .query(async ({ ctx: { instance } }) =>
-      (await instance.getLateMarkers()).map((x) => x.user),
+      (await instance.getLateMarkers()).map((x) => x.marker),
     ),
 
   notifyLateMarkers: procedure.instance.subGroupAdmin
@@ -135,9 +135,13 @@ export const mspAdminInstanceRouter = createTRPCRouter({
         numAcademics: markers.length,
         authorizerId: user.id,
       });
-      await mailer.notifyGenericMarkingOverdue({
-        params: instance.params,
-        markers,
-      });
+
+      console.log(markers);
+      console.log(markers.length);
+
+      // await mailer.notifyGenericMarkingOverdue({
+      //   params: instance.params,
+      //   markers,
+      // });
     }),
 });

--- a/src/server/routers/msp/admin/instace.ts
+++ b/src/server/routers/msp/admin/instace.ts
@@ -121,7 +121,9 @@ export const mspAdminInstanceRouter = createTRPCRouter({
 
   getLateMarkers: procedure.instance.subGroupAdmin
     .output(z.array(userDtoSchema))
-    .query(async ({ ctx: { instance } }) => await instance.getLateMarkers()),
+    .query(async ({ ctx: { instance } }) =>
+      (await instance.getLateMarkers()).map((x) => x.user),
+    ),
 
   notifyLateMarkers: procedure.instance.subGroupAdmin
     .output(z.void())

--- a/src/server/routers/msp/admin/instace.ts
+++ b/src/server/routers/msp/admin/instace.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 
 import {
+  lateBlameSchema,
   markingSubmissionDtoSchema,
   projectDtoSchema,
   readerDtoSchema,
@@ -120,10 +121,12 @@ export const mspAdminInstanceRouter = createTRPCRouter({
     }),
 
   getLateMarkers: procedure.instance.subGroupAdmin
-    .output(z.array(userDtoSchema))
-    .query(async ({ ctx: { instance } }) =>
-      (await instance.getLateMarkers()).map((x) => x.marker),
-    ),
+    .output(
+      z.array(
+        z.object({ marker: userDtoSchema, blame: z.array(lateBlameSchema) }),
+      ),
+    )
+    .query(async ({ ctx: { instance } }) => await instance.getLateMarkers()),
 
   notifyLateMarkers: procedure.instance.subGroupAdmin
     .output(z.void())


### PR DESCRIPTION
I believe this fixes the notify late markers button so it won't hammer absolutely everyone all the time.

I found the easiest way to do this was to add a 'blame' mechanism - in other words, attach a little string that indicates _why_ this particular marker is considered late. I think this is probably quite a useful feature to have for debugging, and could be helpful on the frontend too. I'm therefore considering leaving it in. Thoughts on this?


There's also a chance that an edge case un-accounted for. At the moment, there are two which can come up:
1. Medically voided units don't require marking, but still get recorded as 'requires marking'
2. negotiations should use a different deadline - something like `negotiationStartDate` + 1 week.

